### PR TITLE
Validate MPI replica consistency at epoch start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ sims/lvis_cu3d100_te16deg_axon/lvis_cu3d100_te16deg_axon
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# MacOS
+.DS_Store

--- a/sims/go.mod
+++ b/sims/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/anthonynsimon/bild v0.13.0
-	github.com/emer/axon v1.7.14
+	github.com/emer/axon v1.7.15
 	github.com/emer/emergent v1.3.50
 	github.com/emer/empi v1.0.19
 	github.com/emer/etable v1.1.20

--- a/sims/go.mod
+++ b/sims/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/anthonynsimon/bild v0.13.0
-	github.com/emer/axon v1.7.13
+	github.com/emer/axon v1.7.14
 	github.com/emer/emergent v1.3.50
-	github.com/emer/empi v1.0.17
+	github.com/emer/empi v1.0.19
 	github.com/emer/etable v1.1.20
 	github.com/emer/leabra v1.2.7
 	github.com/emer/vision v1.1.18

--- a/sims/go.sum
+++ b/sims/go.sum
@@ -57,8 +57,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
 github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/emer/axon v1.7.14 h1:hnyiXuzsm+XId8ieJyp6YuoGkXmYkeyO55zeLtx+3Y8=
-github.com/emer/axon v1.7.14/go.mod h1:oI7LzNehBdIKV4cGwcaVO8uNjdgpeUMgYFhX+O2Ae/s=
+github.com/emer/axon v1.7.15 h1:8bz+AVflZ/KXf5uhbig2f4fzyHSyx7a1z/x05rz4W+M=
+github.com/emer/axon v1.7.15/go.mod h1:oI7LzNehBdIKV4cGwcaVO8uNjdgpeUMgYFhX+O2Ae/s=
 github.com/emer/emergent v1.3.50 h1:6Lg6kdwPa2qyE/GOjrIFXX8K9820bTUOCn9mBV4l1rk=
 github.com/emer/emergent v1.3.50/go.mod h1:9oJkmYgl+ZYtjB6wVzET56l04KQJmgiRa1Zn8Shu8pw=
 github.com/emer/empi v1.0.19 h1:se2B3gPWNrjcbGiDMiVAd0Z3Unyy3NCzE2cUFQ0h4xg=

--- a/sims/go.sum
+++ b/sims/go.sum
@@ -57,12 +57,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
 github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/emer/axon v1.7.13 h1:dNQhrVNkkBp9uFxkWC7Aowk+aKE+GDRHFYltVJw1Lrs=
-github.com/emer/axon v1.7.13/go.mod h1:oI7LzNehBdIKV4cGwcaVO8uNjdgpeUMgYFhX+O2Ae/s=
+github.com/emer/axon v1.7.14 h1:hnyiXuzsm+XId8ieJyp6YuoGkXmYkeyO55zeLtx+3Y8=
+github.com/emer/axon v1.7.14/go.mod h1:oI7LzNehBdIKV4cGwcaVO8uNjdgpeUMgYFhX+O2Ae/s=
 github.com/emer/emergent v1.3.50 h1:6Lg6kdwPa2qyE/GOjrIFXX8K9820bTUOCn9mBV4l1rk=
 github.com/emer/emergent v1.3.50/go.mod h1:9oJkmYgl+ZYtjB6wVzET56l04KQJmgiRa1Zn8Shu8pw=
-github.com/emer/empi v1.0.17 h1:1arFWAzdDR9emrKbz2sTGMhfAa+Kk0y3UTeBW1j9ltw=
-github.com/emer/empi v1.0.17/go.mod h1:cwXlhwSb91QvfadOlVRrXvcpLGa1ld3GZme5ygb4kt8=
+github.com/emer/empi v1.0.19 h1:se2B3gPWNrjcbGiDMiVAd0Z3Unyy3NCzE2cUFQ0h4xg=
+github.com/emer/empi v1.0.19/go.mod h1:cwXlhwSb91QvfadOlVRrXvcpLGa1ld3GZme5ygb4kt8=
 github.com/emer/etable v1.1.20 h1:tFsO7ypNn7x0SrOmQotUJS+EU7n32mCHTe94fAMkDRI=
 github.com/emer/etable v1.1.20/go.mod h1:c3VZfmNgAnjICuCAkk/kBEpecLjpj52u2twHFx63+SQ=
 github.com/emer/leabra v1.2.7 h1:J7v2E/ldkT0zb8m3n5AkZW9eRPC06ieFZr5pJd2deUM=


### PR DESCRIPTION
Doesn't work yet, need to wait with merge until Axon fix PR is merged & Axon version 1.15 is released.

- [x] Merge fix into Axon.
- [x] Bump lvis axon dependency.
- [x] Run a long-running test to validate it doesn't diverge anymore.